### PR TITLE
Change default keysize to 2048

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
       <form action="#">
         <div class=formgroup>
           <label for=size>Key size: </label>
-          <input name=size id=size value=1024 />
+          <input name=size id=size value=2048 />
           <div class=clear></div>
         </div>
         <div class=formgroup>


### PR DESCRIPTION
If we're creating a self-signed certificate, we're obviously doing it for the encryption, not the validation.  Why, then, would we default to 1024-bit RSA when THE WHOLE WORLD is deprecating that and switching to higher security keys?!?  http://www.symantec.com/page.jsp?id=1024-bit-migration-faq#phasedout
